### PR TITLE
use vanilla rails pluck instead valium gem

### DIFF
--- a/lib/recurse-delete.rb
+++ b/lib/recurse-delete.rb
@@ -21,8 +21,6 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-require 'valium'
-
 module RecurseDelete
   extend ActiveSupport::Concern
 
@@ -44,7 +42,7 @@ module RecurseDelete
       # get the foreign key
       foreign_key = (assoc.options[:foreign_key] or parent_class.to_s.foreign_key)
       # get all the dependent record ids 
-      dependent_ids = dependent_class.where(foreign_key => parent_ids).value_of(:id)
+      dependent_ids = dependent_class.where(foreign_key => parent_ids).pluck(:id)
       # recurse
       delete_recursively(dependent_class, dependent_ids)
     end

--- a/recurse-delete.gemspec
+++ b/recurse-delete.gemspec
@@ -11,5 +11,4 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activerecord', '>= 3.2.3')
   s.add_dependency('activesupport', '>= 3.2.3')
-  s.add_dependency('valium', '0.5.0')
 end


### PR DESCRIPTION
since rails 3.2.1 we have vanilla method `pluck` for the same purposes as `values_of` is. In this case we can remove `valium` gem. It gives us softer dependency and looks like rails 4 support.  (Because valium gem no longer needed it doesn't support rails 4.) 

http://apidock.com/rails/v4.0.2/ActiveRecord/Calculations/pluck
