### PR TITLE
fix for associations with class_name parameter, issue #7

### DIFF
--- a/lib/recurse-delete.rb
+++ b/lib/recurse-delete.rb
@@ -38,7 +38,7 @@ module RecurseDelete
     end
     assocs.each do |assoc|
       # get the dependent class
-      dependent_class = assoc.name.to_s.classify.constantize
+      dependent_class = assoc.klass
       # get the foreign key
       foreign_key = (assoc.options[:foreign_key] or parent_class.to_s.foreign_key)
       # get all the dependent record ids 


### PR DESCRIPTION
This fix allows the gem to work on associations that specify a class_name which does not match the association name. E.g.:

class Pizza
  has_many :toppings, class_name: :Ingredient, dependent: :delete_all
end